### PR TITLE
Remove heading/body vel, add ENU vel

### DIFF
--- a/ros/transponder2ros/CMakeLists.txt
+++ b/ros/transponder2ros/CMakeLists.txt
@@ -20,6 +20,8 @@ find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(transponder_msgs REQUIRED)
 find_package(GeographicLib REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 # git hash and branch
 execute_process(
@@ -94,6 +96,8 @@ add_executable(odom2transponder_node src/odom2transponder_node.cpp)
         transponder_msgs
         geometry_msgs
         GeographicLib
+        tf2
+        tf2_geometry_msgs
     )
     install(TARGETS
     odom2transponder_node

--- a/ros/transponder2ros/include/transponder2ros/iac_udp_struct.h
+++ b/ros/transponder2ros/include/transponder2ros/iac_udp_struct.h
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 
-const uint8_t TRANSPONDER_UDP_STRUCT_VERISON = 0x04;  // 2025-06-28
+const uint8_t TRANSPONDER_UDP_STRUCT_VERISON = 0x05;  // 2025-10-20
                                                       // Check on the ROS side the versions of the
                                                       // structs you are getting are correct
 
@@ -22,8 +22,9 @@ struct __attribute__((packed)) StructIacTransponder
   int32_t lat;                   // Vehicle longitude [ dd.dd x 10^7 ]
   int32_t lon;                   // Vehicle latitude [ dd.dd x 10^7 ]
   int32_t alt;                   // Vehicle altitude [ mm ]
-  uint16_t heading;              // Vehicle GPS heading [ cdeg ]
-  uint16_t vel;                  // Vehicle speed [ cm/s ]
+  uint16_t v_east;               // Vehicle global velocity in East direction [ cm/s ]
+  uint16_t v_north;              // Vehicle global velocity in North direction [ cm/s ]
+  uint16_t v_up;                 // Vehicle global velocity in Up direction[ cm/s ]
   uint8_t state;                 // Vehicle state [ - ], see transponder_msgs::msg::Transponder
 };
 

--- a/ros/transponder2ros/launch/transponder.launch.py
+++ b/ros/transponder2ros/launch/transponder.launch.py
@@ -39,12 +39,13 @@ def generate_launch_description():
         output="both",
         namespace="transponder",
         parameters=[
-                {'odometry_in' : '/state/odom'},    # Odometry in topic
-                {'transponder_out' : 'out'},        # Transponder out topic
-                {'car' : 1},                        # Car ID
-                {'lat0' : 45.61898},   # Monza      # Reference lla
+                {'odometry_in' : '/state/odom'},        # Odometry in topic
+                {'transponder_out' : 'out'},            # Transponder out topic
+                {'car' : 1},                            # Car ID
+                {'lat0' : 45.61898},   # Monza          # Reference lla
                 {'lon0' : 9.2811880},
                 {'alt0' : 176.61984507},
+                # {'transform_to': 'rear_axle_middle'},  # Optional frame to transform odometry to
         ],
     )
     ld.add_action(node)

--- a/ros/transponder2ros/package.xml
+++ b/ros/transponder2ros/package.xml
@@ -16,6 +16,9 @@
   <depend>geographic_msgs</depend>
   <depend>transponder_msgs</depend>
   <depend>geographiclib</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/ros/transponder2ros/src/debug_node.cpp
+++ b/ros/transponder2ros/src/debug_node.cpp
@@ -37,8 +37,9 @@ class TransponderDebug : public rclcpp::Node
         msg_.car_id = 8;
         msg_.lat = msg_.lat + 0.1;
         msg_.lon = msg_.lon - 0.1;
-        msg_.heading = msg_.heading + 0.03;
-        msg_.vel = msg_.vel + 0.2;
+        msg_.v_east = msg_.v_east + 0.2;
+        msg_.v_north = msg_.v_north - 0.2;
+        msg_.v_up = msg_.v_up + 0.3;
         msg_.state = transponder_msgs::msg::Transponder::STATE_NOMINAL;
 
         pub_Transponder_->publish(msg_);

--- a/ros/transponder2ros/src/transponder2ros/functions_ros.cpp
+++ b/ros/transponder2ros/src/transponder2ros/functions_ros.cpp
@@ -68,8 +68,9 @@ void transponder2ros::publish_Transponder(TransponderUdpPacket transponder)
     msg.lat = transponder.data.lat/1e7;
     msg.lon = transponder.data.lon/1e7;
     msg.alt = transponder.data.alt/1e3;
-    msg.heading = transponder.data.heading/1e2;
-    msg.vel = transponder.data.vel/1e2;
+    msg.v_east = transponder.data.v_east/1e2;
+    msg.v_north = transponder.data.v_north/1e2;
+    msg.v_up = transponder.data.v_up/1e2;
     msg.state = transponder.data.state;
 
     pub_Transponder_->publish(msg);
@@ -102,16 +103,17 @@ void transponder2ros::callback_Transponder(const transponder_msgs::msg::Transpon
     // Need to send Transponder data from here
     StructIacTransponder transponder;
 
-    transponder.version = TRANSPONDER_UDP_STRUCT_VERISON;   // Struct version
-    transponder.sec = msg->header.stamp.sec;                // UTC time [ s ]
-    transponder.nanosec = msg->header.stamp.nanosec;        // UTC time nanoseconds [ ns ]
-    transponder.car_id = msg->car_id;                       // Car ID [ - ]
-    transponder.lat = msg->lat*1e7;                         // Vehicle longitude [ dd.dd x 10^7 ]
-    transponder.lon = msg->lon*1e7;                         // Vehicle latitude [ dd.dd x 10^7 ]
-    transponder.alt = msg->alt*1e3;                         // Vehicle altitude [ mm ]
-    transponder.heading = msg->heading*1e2;                 // Vehicle GPS heading [ cdeg ]
-    transponder.vel = (msg->vel > 0) ? msg->vel*1e2 : 0;    // Vehicle speed, force positive [ cm/s ]
-    transponder.state = msg->state;                         // Vehicle state [ - ]
+    transponder.version = TRANSPONDER_UDP_STRUCT_VERISON;               // Struct version
+    transponder.sec = msg->header.stamp.sec;                            // UTC time [ s ]
+    transponder.nanosec = msg->header.stamp.nanosec;                    // UTC time nanoseconds [ ns ]
+    transponder.car_id = msg->car_id;                                   // Car ID [ - ]
+    transponder.lat = msg->lat*1e7;                                     // Vehicle longitude [ dd.dd x 10^7 ]
+    transponder.lon = msg->lon*1e7;                                     // Vehicle latitude [ dd.dd x 10^7 ]
+    transponder.alt = msg->alt*1e3;                                     // Vehicle altitude [ mm ]
+    transponder.v_east = (msg->v_east > 0) ? msg->v_east*1e2 : 0;       // Vehicle velocity East [ cm/s ]
+    transponder.v_north = (msg->v_north > 0) ? msg->v_north*1e2 : 0;    // Vehicle velocity North [ cm/s ]
+    transponder.v_up = (msg->v_up > 0) ? msg->v_up*1e2 : 0;             // Vehicle velocity Up [ cm/s ]
+    transponder.state = msg->state;                                     // Vehicle state [ - ]
   
     // Push data
     push_udp(transponder);

--- a/ros/transponder2ros/src/transponder2ros/functions_udp.cpp
+++ b/ros/transponder2ros/src/transponder2ros/functions_udp.cpp
@@ -88,8 +88,8 @@ void transponder2ros::push_udp(StructIacTransponder data)
     // Debugging
     if (0)
     {
-        RCLCPP_INFO(this->get_logger(), "Sending %5.2d, %5.2d, %5.2d",
-        udp_packet.data.lat, udp_packet.data.lon, udp_packet.data.vel);
+        RCLCPP_INFO(this->get_logger(), "Sending %5.2d, %5.2d",
+        udp_packet.data.lat, udp_packet.data.lon);
     }
 
     // All done

--- a/ros/transponder_msgs/msg/Transponder.msg
+++ b/ros/transponder_msgs/msg/Transponder.msg
@@ -6,8 +6,9 @@ uint8   car_id          # Car ID [ - ]
 float64 lat             # Vehicle longitude, centre of rear axle [ dd.dd ]
 float64 lon             # Vehicle latitude, centre of rear axle [ dd.dd ]
 float32 alt             # Vehicle altitude (ellipsoid), centre of rear axle [ m ]
-float32 heading         # Vehicle heading, GPS style, North = 0, East = 90 [ deg ]
-float32 vel             # Vehicle speed, Vx_body [ m/s ]
+float32 v_east          # Vehicle global velocity in East direction [ m/s ]
+float32 v_north         # Vehicle global velocity in North direction [ m/s ]
+float32 v_up            # Vehicle global velocity in Up direction [ m/s ]
 uint8   state           # Vehicle state, see iac_udp_struct.h [ - ]
 
 # Vehicle states


### PR DESCRIPTION
I think this will allow us to have better annotated ground truth data.  We will have some time delta between our perception data and the received message, so having full ENU velocity will help us interpolate better.

Within a few degrees, heading can be inferred as atan(vy,vx).  I think it is more critical for us to have the global velocity than heading, so took it out as a space-saving method.